### PR TITLE
Fix typo(uia): issuers instead of issues

### DIFF
--- a/src/core/uia.js
+++ b/src/core/uia.js
@@ -148,9 +148,9 @@ shared.getIssuerByAddress = (req, cb) => {
   }
   return (async () => {
     try {
-      const issues = await app.sdb.find('Issuer', { address: req.params.address })
+      const issuers = await app.sdb.find('Issuer', { address: req.params.address })
       if (!issuers || issuers.length === 0) return cb('Issuer not found')
-      return cb(null, { issuer: issues[0] })
+      return cb(null, { issuer: issuers[0] })
     } catch (dbErr) {
       return cb(`Failed to get issuer: ${dbErr}`)
     }


### PR DESCRIPTION
Dear @sqfasd 

I fixed the following error:

If I start the ASCH blockchain and request the publisher by __address__   `http://localhost:4096/api/uia/issuers/AHMCKebuL2nRYDgszf9J2KjVZzAw95WUyB`

I get the following response:
```json
{
  "success":false,
  "error":"Failed to get issuer: ReferenceError: issuers is not defined"
}
```
The ___correct___ response should be:  
```json
{
  "success":false,
  "error":"Issuer not found"
}
```

The __ReferenceError__ occurs because the the property `issuers` is not defined in the function __getIssuerByAddress__

All the best
a1300

<br/>

#### Test this pull request
> ```bash
> git clone https://github.com/AschPlatform/asch-core
> git fetch origin pull/22/head:fix_issuers_typo
> git checkout fix_issuers_typo
> ```